### PR TITLE
added scrollbox/fixed background for chat show

### DIFF
--- a/app/assets/javascripts/channels/messages.js
+++ b/app/assets/javascripts/channels/messages.js
@@ -9,6 +9,7 @@ function createMessageChannel() {
           return $('#messages').append(this.renderMessage(data));
         },
         renderMessage: function(data) {
+    // returns html that mimics _message.html.erb template
     return "<p><img src='" + data.user_photo_url + "' class='bh-avatar-sm'> " + data.message + "</p>";
   },
       });

--- a/app/assets/stylesheets/components/_bh-chat-scrollbox.scss
+++ b/app/assets/stylesheets/components/_bh-chat-scrollbox.scss
@@ -1,0 +1,11 @@
+.bh-chat-scrollbox {
+  overflow: scroll;
+  height: 65vh;
+  width: 100vw;
+}
+
+#chat-window-body {
+  height:100vh;
+  margin: 0;
+  position: fixed;
+}

--- a/app/assets/stylesheets/components/_bh-no-scroll.scss
+++ b/app/assets/stylesheets/components/_bh-no-scroll.scss
@@ -1,0 +1,3 @@
+.bh-no-scroll {
+  overflow: hidden;
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -10,4 +10,6 @@
 @import "bh-banner";
 @import "bh-select";
 @import "bh-nav-header";
+@import "bh-chat-scrollbox";
+@import "bh-no-scroll";
 

--- a/app/views/chats/show.html.erb
+++ b/app/views/chats/show.html.erb
@@ -1,14 +1,13 @@
-<div>
+<div id="chat-window-body" class="bh-no-scroll">
   <h5>Chat with <%= @other_user.first_name %></h5>
   <% if @chat.messages.any? %>
-    <div id="messages">
+    <div id="messages" class="bh-chat-scrollbox">
       <%= render partial: 'messages/message', collection: @chat.messages.order(id: :asc)%>
     </div>
   <% else %>
     <div id="messages">
     </div>
   <% end %>
-</div>
 <%= render partial: 'messages/message_form', locals: {message: @message, chat: @chat}%>
 </div>
 
@@ -18,4 +17,10 @@
   // app/assets/javascripts/channels/messages.js
   messageForm();
   // app/assets/javascripts/messages_form.js
+
+  // scroll to bottom of chat on load
+  window.onload=function () {
+     var chatBox = document.getElementById("messages");
+     chatBox.scrollTop = chatBox.scrollHeight;
+}
 </script>


### PR DESCRIPTION
chat auto scrolls to bottom (most recent messages) on page load. background fixed, but chat box scrolls

![image](https://user-images.githubusercontent.com/9841162/69920582-cb13bc80-1457-11ea-97e7-a8138ab194bf.png)
